### PR TITLE
Fix image agent throttle PID controller input

### DIFF
--- a/bird_view/models/image.py
+++ b/bird_view/models/image.py
@@ -162,7 +162,7 @@ class ImageAgent(Agent):
         n = self.steer_points.get(str(_cmd), 1)
         closest = common.project_point_to_circle(targets[n], c, r)
         
-        acceleration = np.clip(target_speed - speed, 0.0, 1.0)
+        acceleration = target_speed - speed
 
         v = [1.0, 0.0, 0.0]
         w = [closest[0], closest[1], 0.0]


### PR DESCRIPTION
The `acceleration` calculated is the input error for the throttle PID controller at line 172. By clipping it here to be positive, the PID controller never gets a negative error, so it won't become stable. This PR removes the clipping fully. Alternatively, it could be clipped e.g. between -1 and 1.